### PR TITLE
Remove `Reference.AssemblyPath` from DnaLibrary XML Schema, that has …

### DIFF
--- a/XmlSchemas/ExcelDna.DnaLibrary.xsd
+++ b/XmlSchemas/ExcelDna.DnaLibrary.xsd
@@ -176,9 +176,6 @@
         <xs:attribute name="Path"
                       use="optional"
                       type="xs:string" />
-        <xs:attribute name="AssemblyPath"
-                      use="optional"
-                      type="xs:string" />
         <xs:attribute name="Pack"
                       use="optional"
                       type="Boolean" />


### PR DESCRIPTION
…been deprecated

See https://github.com/Excel-DNA/ExcelDna/pull/194#issuecomment-390469854